### PR TITLE
Add support for KubeletCertificateAuthority for api server

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -181,6 +181,7 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		// @note we are making assumption were using the ones created by the pki model, not custom defined ones
 		kubeAPIServer.KubeletClientCertificate = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.pem")
 		kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api-key.pem")
+		kubeAPIServer.KubeletCertificateAuthority = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 	}
 
 	if b.IsKubernetesGTE("1.7") {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -383,6 +383,8 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	if b.UseSecureKubelet() {
 		// @TODO these filenames need to be a constant somewhere
 		c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
+		c.TLSCertFile = filepath.Join(b.PathSrvKubernetes(), "kubelet-tls.cert")
+		c.TLSPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "kubelet-tls.key")
 	}
 
 	if b.InstanceGroup.Spec.Kubelet != nil {

--- a/nodeup/pkg/model/secrets.go
+++ b/nodeup/pkg/model/secrets.go
@@ -73,6 +73,15 @@ func (b *SecretBuilder) Build(c *fi.ModelBuilderContext) error {
 			c.AddTask(t)
 		}
 	}
+	{
+		if err := b.writeCertificate(c, "kubelet-tls"); err != nil {
+			return err
+		}
+
+		if err := b.writePrivateKey(c, "kubelet-tls"); err != nil {
+			return err
+		}
+	}
 
 	// if we are not a master we can stop here
 	if !b.IsMaster {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -158,6 +158,10 @@ type KubeletConfigSpec struct {
 	CAdvisorPort *int32 `json:"cadvisorPort,omitempty" flag:"cadvisor-port"`
 	// ProtectKernelDefaults Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// TLSCertFile File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert).
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// File containing x509 private key matching --tls-cert-file.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy
@@ -229,6 +233,8 @@ type KubeAPIServerConfig struct {
 	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
 	// KubeletClientKey is the path of a private to secure communication between api and kubelet
 	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// KubeletCertificateAuthority is the path to a cert file for the certificate authority.
+	KubeletCertificateAuthority string `json:"kubeletCertificateAuthority,omitempty" flag:"kubelet-certificate-authority"`
 	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections

--- a/pkg/apis/kops/v1alpha1/componentconfig.go
+++ b/pkg/apis/kops/v1alpha1/componentconfig.go
@@ -158,6 +158,10 @@ type KubeletConfigSpec struct {
 	CAdvisorPort *int32 `json:"cadvisorPort,omitempty" flag:"cadvisor-port"`
 	// ProtectKernelDefaults Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// TLSCertFile File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert).
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// File containing x509 private key matching --tls-cert-file.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy
@@ -229,6 +233,8 @@ type KubeAPIServerConfig struct {
 	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
 	// KubeletClientKey is the path of a private to secure communication between api and kubelet
 	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// KubeletCertificateAuthority is the path to a cert file for the certificate authority.
+	KubeletCertificateAuthority string `json:"kubeletCertificateAuthority,omitempty" flag:"kubelet-certificate-authority"`
 	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1825,6 +1825,7 @@ func autoConvert_v1alpha1_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.RuntimeConfig = in.RuntimeConfig
 	out.KubeletClientCertificate = in.KubeletClientCertificate
 	out.KubeletClientKey = in.KubeletClientKey
+	out.KubeletCertificateAuthority = in.KubeletCertificateAuthority
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -1887,6 +1888,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha1_KubeAPIServerConfig(in *ko
 	out.RuntimeConfig = in.RuntimeConfig
 	out.KubeletClientCertificate = in.KubeletClientCertificate
 	out.KubeletClientKey = in.KubeletClientKey
+	out.KubeletCertificateAuthority = in.KubeletCertificateAuthority
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -2170,6 +2172,8 @@ func autoConvert_v1alpha1_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.MakeIptablesUtilChains = in.MakeIptablesUtilChains
 	out.CAdvisorPort = in.CAdvisorPort
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 
@@ -2238,6 +2242,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha1_KubeletConfigSpec(in *kops.K
 	out.MakeIptablesUtilChains = in.MakeIptablesUtilChains
 	out.CAdvisorPort = in.CAdvisorPort
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -158,6 +158,10 @@ type KubeletConfigSpec struct {
 	CAdvisorPort *int32 `json:"cadvisorPort,omitempty" flag:"cadvisor-port"`
 	// ProtectKernelDefaults Default kubelet behaviour for kernel tuning. If set, kubelet errors if any of kernel tunables is different than kubelet defaults.
 	ProtectKernelDefaults *bool `json:"protectKernelDefaults,omitempty" flag:"protect-kernel-defaults"`
+	// TLSCertFile File containing x509 Certificate used for serving HTTPS (with intermediate certs, if any, concatenated after server cert).
+	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// File containing x509 private key matching --tls-cert-file.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 }
 
 // KubeProxyConfig defined the configuration for a proxy
@@ -229,6 +233,8 @@ type KubeAPIServerConfig struct {
 	KubeletClientCertificate string `json:"kubeletClientCertificate,omitempty" flag:"kubelet-client-certificate"`
 	// KubeletClientKey is the path of a private to secure communication between api and kubelet
 	KubeletClientKey string `json:"kubeletClientKey,omitempty" flag:"kubelet-client-key"`
+	// KubeletCertificateAuthority is the path to a cert file for the certificate authority.
+	KubeletCertificateAuthority string `json:"kubeletCertificateAuthority,omitempty" flag:"kubelet-certificate-authority"`
 	// AnonymousAuth indicates if anonymous authentication is permitted
 	AnonymousAuth *bool `json:"anonymousAuth,omitempty" flag:"anonymous-auth"`
 	// KubeletPreferredAddressTypes is a list of the preferred NodeAddressTypes to use for kubelet connections

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2087,6 +2087,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.RuntimeConfig = in.RuntimeConfig
 	out.KubeletClientCertificate = in.KubeletClientCertificate
 	out.KubeletClientKey = in.KubeletClientKey
+	out.KubeletCertificateAuthority = in.KubeletCertificateAuthority
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -2149,6 +2150,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.RuntimeConfig = in.RuntimeConfig
 	out.KubeletClientCertificate = in.KubeletClientCertificate
 	out.KubeletClientKey = in.KubeletClientKey
+	out.KubeletCertificateAuthority = in.KubeletCertificateAuthority
 	out.AnonymousAuth = in.AnonymousAuth
 	out.KubeletPreferredAddressTypes = in.KubeletPreferredAddressTypes
 	out.StorageBackend = in.StorageBackend
@@ -2432,6 +2434,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.MakeIptablesUtilChains = in.MakeIptablesUtilChains
 	out.CAdvisorPort = in.CAdvisorPort
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 
@@ -2500,6 +2504,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.MakeIptablesUtilChains = in.MakeIptablesUtilChains
 	out.CAdvisorPort = in.CAdvisorPort
 	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -344,6 +344,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/issued/*"}, ""),
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kube-proxy/*"}, ""),
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kubelet/*"}, ""),
+							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/private/kubelet-tls/*"}, ""),
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/pki/ssh/*"}, ""),
 							strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/secrets/dockerconfig"}, ""),
 						),

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -70,6 +70,18 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		})
 	}
 	{
+		alternativeNames := []string{fmt.Sprintf("*.ec2.internal")}
+		t := &fitasks.Keypair{
+			Name:           fi.String("kubelet-tls"),
+			Lifecycle:      b.Lifecycle,
+			AlternateNames: alternativeNames,
+			Subject:        "cn=kubelet-tls",
+			Type:           "server",
+			Signer:         defaultCA,
+		}
+		c.AddTask(t)
+	}
+	{
 		t := &fitasks.Keypair{
 			Name:      fi.String("kube-scheduler"),
 			Lifecycle: b.Lifecycle,


### PR DESCRIPTION
This now generates TLS certificates for kubelet instead of
letting each kubelet generate a self-signed certificate.