### PR TITLE
Hardcode to keep only 1 log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 go:
-  - 1.8
+  # 1.8 is now best-effort; we recommend 1.9; we are starting to use type aliases in libraries
+  # - 1.8
   - 1.9
   - "1.10"
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BAZELIMAGES=$(BAZELDIST)/images
 BAZELUPLOAD=$(BAZELBUILD)/upload
 UID:=$(shell id -u)
 GID:=$(shell id -g)
-TESTABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor" hack/.packages)
+TESTABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/vendor" hack/.packages)
 # We need to ignore clientsets because of kubernetes/kubernetes#60584
 GOVETABLE_PACKAGES:=$(shell egrep -v "k8s.io/kops/cloudmock|k8s.io/kops/vendor|clientset/fake" hack/.packages)
 BAZEL_OPTIONS?=
@@ -192,15 +192,19 @@ upup/models/bindata.go: ${GOBINDATA} ${UPUP_MODELS_BINDATA_SOURCES}
 
 # Build in a docker container with golang 1.X
 # Used to test we have not broken 1.X
-# 1.8 is preferred, 1.9 is coming soon so we have a target for it
+# 1.9 is preferred, 1.10 is likely to be the default soon.  1.8 is best-effort
 .PHONY: check-builds-in-go18
 check-builds-in-go18:
-	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.8 make -C /go/src/k8s.io/kops ci
+	# Note we only check that kops builds; we know the tests don't compile because of type aliasing in uber zap
+	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.8 make -C /go/src/k8s.io/kops kops
 
 .PHONY: check-builds-in-go19
 check-builds-in-go19:
 	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.9 make -C /go/src/k8s.io/kops ci
 
+.PHONY: check-builds-in-go110
+check-builds-in-go110:
+	docker run -v ${GOPATH_1ST}/src/k8s.io/kops:/go/src/k8s.io/kops golang:1.10 make -C /go/src/k8s.io/kops ci
 
 .PHONY: codegen
 codegen: kops-gobindata

--- a/channels/alpha
+++ b/channels/alpha
@@ -56,6 +56,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.10.0-alpha.1"
+    recommendedVersion: "1.10.0-alpha.1"
+    #requiredVersion: 1.10.0
+    kubernetesVersion: 1.10.3
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.1
     #requiredVersion: 1.9.0

--- a/channels/stable
+++ b/channels/stable
@@ -31,6 +31,9 @@ spec:
     networking:
       kubenet: {}
   kubernetesVersions:
+  - range: ">=1.10.0"
+    recommendedVersion: 1.10.3
+    requiredVersion: 1.10.0
   - range: ">=1.9.0"
     recommendedVersion: 1.9.6
     requiredVersion: 1.9.0
@@ -50,6 +53,10 @@ spec:
     recommendedVersion: 1.4.12
     requiredVersion: 1.4.2
   kopsVersions:
+  - range: ">=1.10.0-alpha.1"
+    recommendedVersion: "1.10.0-alpha.1"
+    #requiredVersion: 1.10.0
+    kubernetesVersion: 1.10.3
   - range: ">=1.9.0-alpha.1"
     recommendedVersion: 1.9.0
     #requiredVersion: 1.9.0

--- a/cmd/kops/rollingupdatecluster.go
+++ b/cmd/kops/rollingupdatecluster.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -181,7 +182,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&options.BastionInterval, "bastion-interval", options.BastionInterval, "Time to wait between restarting bastions")
 	cmd.Flags().BoolVarP(&options.Interactive, "interactive", "i", options.Interactive, "Prompt to continue after each instance is updated")
 	cmd.Flags().StringSliceVar(&options.InstanceGroups, "instance-group", options.InstanceGroups, "List of instance groups to update (defaults to all if not specified)")
-	cmd.Flags().StringSliceVar(&options.InstanceGroupRoles, "instance-group-roles", options.InstanceGroupRoles, "If specified, only instance groups of the specified role will be updated")
+	cmd.Flags().StringSliceVar(&options.InstanceGroupRoles, "instance-group-roles", options.InstanceGroupRoles, "If specified, only instance groups of the specified role will be updated (e.g. Master,Node,Bastion)")
 
 	if featureflag.DrainAndValidateRollingUpdate.Enabled() {
 		cmd.Flags().BoolVar(&options.FailOnDrainError, "fail-on-drain-error", true, "The rolling-update will fail if draining a node fails.")
@@ -295,7 +296,7 @@ func RunRollingUpdateCluster(f *util.Factory, out io.Writer, options *RollingUpd
 
 		for _, ig := range instanceGroups {
 			for _, role := range options.InstanceGroupRoles {
-				if ig.Spec.Role == api.InstanceGroupRole(role) {
+				if ig.Spec.Role == api.InstanceGroupRole(strings.Title(strings.ToLower(role))) {
 					filtered = append(filtered, ig)
 					continue
 				}

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -74,7 +74,7 @@ kops rolling-update cluster [flags]
       --force                          Force rolling update, even if no changes
   -h, --help                           help for cluster
       --instance-group strings         List of instance groups to update (defaults to all if not specified)
-      --instance-group-roles strings   If specified, only instance groups of the specified role will be updated
+      --instance-group-roles strings   If specified, only instance groups of the specified role will be updated (e.g. Master,Node,Bastion)
   -i, --interactive                    Prompt to continue after each instance is updated
       --master-interval duration       Time to wait between restarting masters (default 5m0s)
       --node-interval duration         Time to wait between restarting nodes (default 4m0s)

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,7 +70,7 @@ https://aws.amazon.com/cli/
  
  The officially supported way of installing the tool is with `pip`:
  
-```python
+```bash
 pip install awscli
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,20 +62,27 @@ wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 ```
+# Installing AWS CLI Tools
 
+https://aws.amazon.com/cli/
 
-## Installing AWS CLI Tools
+ On MacOS, Windows and Linux OS:
+ 
+ The officially supported way of installing the tool is with `pip`:
+ 
+```pip install awscli
+```
+
+##### _OR use these alternative methods for MacOS and Windows:_
 
 ### MacOS
 
-The officially supported way of installing the tool is with `pip`:
-
-```bash
-pip install awscli
-```
-
-You can also grab the tool with homebrew, although this is not officially supported by AWS.
-
+You can grab the tool with homebrew, although this is not officially supported by AWS.
 ```bash
 brew update && brew install awscli
 ```
+
+### Windows
+
+You can download the MSI installer from this page and follow the steps through the installer which requires no other dependencies: 
+https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-windows.html

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,7 +70,8 @@ https://aws.amazon.com/cli/
  
  The officially supported way of installing the tool is with `pip`:
  
-```pip install awscli
+```python
+pip install awscli
 ```
 
 ##### _OR use these alternative methods for MacOS and Windows:_

--- a/docs/tutorial/digitalocean.md
+++ b/docs/tutorial/digitalocean.md
@@ -25,7 +25,7 @@ export S3_ACCESS_KEY_ID=<access-key-id>  # where <access-key-id> is the Spaces A
 export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API Secret Key for your bucket
 
 # this is required since DigitalOcean support is currently in alpha so it is feature gated
-export KOPS_FEATURE_FLAGS="AlphaAllowDO" # this is required since
+export KOPS_FEATURE_FLAGS="AlphaAllowDO"
 ```
 
 ## Creating a Cluster

--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -123,7 +123,7 @@ func (b *LogrotateBuilder) addLogRotate(c *fi.ModelBuilderContext, name, path st
 
 	lines := []string{
 		path + "{",
-		"  rotate 5",
+		"  rotate 1",
 		"  copytruncate",
 		"  missingok",
 		"  notifempty",

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -50,6 +50,8 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 	// StorageOpts is a series of options passed to the storage driver
 	StorageOpts []string `json:"storageOpts,omitempty" flag:"storage-opt,repeat"`
+	// UserNamespaceRemap sets the user namespace remapping option for the docker daemon
+	UserNamespaceRemap string `json:"userNamespaceRemap,omitempty" flag:"userns-remap"`
 	// Version is consumed by the nodeup and used to pick the docker version
 	Version *string `json:"version,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha1/dockerconfig.go
@@ -50,6 +50,8 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 	// StorageOpts is a series of options passed to the storage driver
 	StorageOpts []string `json:"storageOpts,omitempty" flag:"storage-opt,repeat"`
+	// UserNamespaceRemap sets the user namespace remapping option for the docker daemon
+	UserNamespaceRemap string `json:"userNamespaceRemap,omitempty" flag:"userns-remap"`
 	// Version is consumed by the nodeup and used to pick the docker version
 	Version *string `json:"version,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha1/zz_generated.conversion.go
@@ -1350,6 +1350,7 @@ func autoConvert_v1alpha1_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.RegistryMirrors = in.RegistryMirrors
 	out.Storage = in.Storage
 	out.StorageOpts = in.StorageOpts
+	out.UserNamespaceRemap = in.UserNamespaceRemap
 	out.Version = in.Version
 	return nil
 }
@@ -1378,6 +1379,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha1_DockerConfig(in *kops.DockerConfi
 	out.RegistryMirrors = in.RegistryMirrors
 	out.Storage = in.Storage
 	out.StorageOpts = in.StorageOpts
+	out.UserNamespaceRemap = in.UserNamespaceRemap
 	out.Version = in.Version
 	return nil
 }

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -50,6 +50,8 @@ type DockerConfig struct {
 	Storage *string `json:"storage,omitempty" flag:"storage-driver"`
 	// StorageOpts is a series of options passed to the storage driver
 	StorageOpts []string `json:"storageOpts,omitempty" flag:"storage-opt,repeat"`
+	// UserNamespaceRemap sets the user namespace remapping option for the docker daemon
+	UserNamespaceRemap string `json:"userNamespaceRemap,omitempty" flag:"userns-remap"`
 	// Version is consumed by the nodeup and used to pick the docker version
 	Version *string `json:"version,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1451,6 +1451,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.RegistryMirrors = in.RegistryMirrors
 	out.Storage = in.Storage
 	out.StorageOpts = in.StorageOpts
+	out.UserNamespaceRemap = in.UserNamespaceRemap
 	out.Version = in.Version
 	return nil
 }
@@ -1479,6 +1480,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.RegistryMirrors = in.RegistryMirrors
 	out.Storage = in.Storage
 	out.StorageOpts = in.StorageOpts
+	out.UserNamespaceRemap = in.UserNamespaceRemap
 	out.Version = in.Version
 	return nil
 }

--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -33,6 +33,8 @@ go_library(
         "//pkg/pki:go_default_library",
         "//pkg/tokens:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/cloudup/alitasks:go_default_library",
+        "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/dotasks:go_default_library",

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/alitasks"
+	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/dotasks"
@@ -39,6 +41,7 @@ const (
 	DefaultAWSEtcdVolumeType = "gp2"
 	DefaultAWSEtcdVolumeIops = 100
 	DefaultGCEEtcdVolumeType = "pd-ssd"
+	DefaultALIEtcdVolumeType = "cloud_ssd"
 )
 
 // MasterVolumeBuilder builds master EBS volumes
@@ -103,6 +106,8 @@ func (b *MasterVolumeBuilder) Build(c *fi.ModelBuilderContext) error {
 				if err != nil {
 					return err
 				}
+			case kops.CloudProviderALI:
+				b.addALIVolume(c, name, volumeSize, zone, etcd, m, allMembers)
 			default:
 				return fmt.Errorf("unknown cloudprovider %q", b.Cluster.Spec.CloudProvider)
 			}
@@ -258,4 +263,40 @@ func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name
 	c.AddTask(t)
 
 	return nil
+}
+
+func (b *MasterVolumeBuilder) addALIVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd *kops.EtcdClusterSpec, m *kops.EtcdMemberSpec, allMembers []string) {
+	//Alicloud does not support volumeName starts with number
+	name = "v" + name
+	volumeType := fi.StringValue(m.VolumeType)
+	if volumeType == "" {
+		volumeType = DefaultALIEtcdVolumeType
+	}
+
+	// The tags are how protokube knows to mount the volume and use it for etcd
+	tags := make(map[string]string)
+
+	// Apply all user defined labels on the volumes
+	for k, v := range b.Cluster.Spec.CloudLabels {
+		tags[k] = v
+	}
+
+	// This is the configuration of the etcd cluster
+	tags[aliup.TagNameEtcdClusterPrefix+etcd.Name] = m.Name + "/" + strings.Join(allMembers, ",")
+	// This says "only mount on a master"
+	tags[aliup.TagNameRolePrefix+"master"] = "1"
+
+	encrypted := fi.BoolValue(m.EncryptedVolume)
+
+	t := &alitasks.Disk{
+		Lifecycle:    b.Lifecycle,
+		Name:         s(name),
+		ZoneId:       s(zone),
+		SizeGB:       fi.Int(int(volumeSize)),
+		DiskCategory: s(volumeType),
+		Encrypted:    fi.Bool(encrypted),
+		Tags:         tags,
+	}
+
+	c.AddTask(t)
 }

--- a/upup/pkg/fi/cloudup/aliup/ali_cloud.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_cloud.go
@@ -38,6 +38,8 @@ import (
 )
 
 const TagClusterName = "KubernetesCluster"
+const TagNameRolePrefix = "k8s.io/role/"
+const TagNameEtcdClusterPrefix = "k8s.io/etcd/"
 
 // This is for statistic purpose.
 var KubernetesKopsIdentity = fmt.Sprintf("Kubernetes.Kops/%s", prj.Version)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -423,9 +423,30 @@ func (c *ApplyClusterCmd) Run() error {
 			aliCloud := cloud.(aliup.ALICloud)
 			region = aliCloud.Region()
 			l.AddTypes(map[string]interface{}{
-				"Vpc":     &alitasks.VPC{},
-				"VSwitch": &alitasks.VSwitch{},
+				"Vpc":                   &alitasks.VPC{},
+				"VSwitch":               &alitasks.VSwitch{},
+				"Disk":                  &alitasks.Disk{},
+				"SecurityGroup":         &alitasks.SecurityGroup{},
+				"SecurityGroupRule":     &alitasks.SecurityGroupRule{},
+				"LoadBalancer":          &alitasks.LoadBalancer{},
+				"LoadBalancerListener":  &alitasks.LoadBalancerListener{},
+				"LoadBalancerWhiteList": &alitasks.LoadBalancerWhiteList{},
+				"AutoscalingGroup":      &alitasks.ScalingGroup{},
+				"LaunchConfiguration":   &alitasks.LaunchConfiguration{},
+				"RAMPolicy":             &alitasks.RAMPolicy{},
+				"RAMRole":               &alitasks.RAMRole{},
+				"SSHKey":                &alitasks.SSHKey{},
 			})
+
+			if len(sshPublicKeys) == 0 {
+				return fmt.Errorf("SSH public key must be specified when running with ALICloud (create with `kops create secret --name %s sshpublickey admin -i ~/.ssh/id_rsa.pub`)", cluster.ObjectMeta.Name)
+			}
+
+			modelContext.SSHPublicKeys = sshPublicKeys
+
+			if len(sshPublicKeys) != 1 {
+				return fmt.Errorf("Exactly one 'admin' SSH public key can be specified when running with ALICloud; please delete a key using `kops delete secret`")
+			}
 		}
 
 	case kops.CloudProviderVSphere:
@@ -592,7 +613,12 @@ func (c *ApplyClusterCmd) Run() error {
 				}
 				l.Builders = append(l.Builders,
 					&model.MasterVolumeBuilder{KopsModelContext: modelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.APILoadBalancerModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
 					&alimodel.NetWorkModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.RAMModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.SSHKeyModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.FirewallModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.ExternalAccessModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
 				)
 
 			case kops.CloudProviderVSphere:
@@ -665,6 +691,19 @@ func (c *ApplyClusterCmd) Run() error {
 
 			l.Builders = append(l.Builders, &gcemodel.AutoscalingGroupModelBuilder{
 				GCEModelContext: gceModelContext,
+				BootstrapScript: bootstrapScriptBuilder,
+				Lifecycle:       &clusterLifecycle,
+			})
+		}
+
+	case kops.CloudProviderALI:
+		{
+			aliModelContext := &alimodel.ALIModelContext{
+				KopsModelContext: modelContext,
+			}
+
+			l.Builders = append(l.Builders, &alimodel.ScalingGroupModelBuilder{
+				ALIModelContext: aliModelContext,
 				BootstrapScript: bootstrapScriptBuilder,
 				Lifecycle:       &clusterLifecycle,
 			})

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -207,7 +207,7 @@ func (s *S3Context) checkDefaultEncryption(region string, bucket string) bool {
 		// the following cases might lead to the operation failing:
 		// 1. A deny policy on s3:GetEncryptionConfiguration
 		// 2. No default encryption policy set
-		glog.Warningf("Unable to read bucket encryption policy: will encrypt using AES256")
+		glog.V(8).Infof("Unable to read bucket encryption policy: will encrypt using AES256")
 		return false
 	}
 


### PR DESCRIPTION
All of the logs that `kops` configures to rotate are sent to syslog so keeping only 1 log is sufficient.